### PR TITLE
Fix build script comparison and add CI checks

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,18 @@
+name: ShellCheck
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run tests
+        run: |
+          tests/test_shellcheck.sh

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# WORK IN PROCESS!
-This is still a work in process, it's for education purposes only. It makes our gl-ar150 run openwrt with HAK5 pineapples skin. 
+# WORK IN PROGRESS!
+This project is still a work in progress and is for educational purposes only. It makes our GL-AR150 run OpenWrt with the Hak5 Pineapple skin.
 
 ### Firmware
 If you have something that is missing in the build (like firmware) let me know. I made it as complete as possible but I can't know all the firmwares.
 
 ## How To Run
 
-The most common way to build the firmware is simply to run `build_pineapple.sh`. This will check for newer upstream code, download it and compile the firmware for the ar-150. If your currently synced code/built firmware is at its newest, nothing will be done. 
+The most common way to build the firmware is simply to run `build_pineapple.sh`. This will check for newer upstream code, download it and compile the firmware for the GL-AR150. If your currently synced code or built firmware is up to date, nothing will be done.
 There are several flags you can use though. 
 - `-f` will force a build. Traditionally, if the currently synced upstream code is at its most current, the script will not build the code if it was already built on said codebase. This will force a rebuild to take place. 
 - `-c` will make a clean build. This will delete all upstream code, download the most recent (again) and compile the firmware. 

--- a/build_pineapple.sh
+++ b/build_pineapple.sh
@@ -48,7 +48,7 @@ install_scripts() {
 }
 
 build_firmware() {
-    echo "Everything is ready to start the build, grab some coffe this can take a long time (90 minutes or more!)"
+    echo "Everything is ready to start the build, grab some coffee this can take a long time (90 minutes or more!)"
     sleep 3
     cd "$top/openwrt-cc"
     make download
@@ -76,7 +76,7 @@ full_build() {
         first_run
     fi
     
-    if [ "$upstream_version" > "$current_version" ]; then
+    if [ "$upstream_version" \> "$current_version" ]; then
         echo "extracting firmware now."
         extract_firmware
     fi

--- a/tests/test_shellcheck.sh
+++ b/tests/test_shellcheck.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+SCRIPT_DIR="$(dirname "$0")"
+shellcheck -S error "$SCRIPT_DIR/../build_pineapple.sh"


### PR DESCRIPTION
## Summary
- correct upstream version comparison and spelling in `build_pineapple.sh`
- tidy wording in `README.md`
- add ShellCheck based test
- run the test in GitHub Actions

## Testing
- `tests/test_shellcheck.sh`


------
https://chatgpt.com/codex/tasks/task_e_68419c9ef2008326a04c506a95a09ad4